### PR TITLE
closing request and response body

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ dev: ${vagrant}
 	vagrant up --provision
 	@echo "You can now get to mesos at http://192.168.33.10:5050 and http://192.168.33.10:5050/api/v1"
 
-smoke:
+smoke: ${vagrant}
 	@go test -v github.com/miroswan/mesops/test/smoke
 
 unit:

--- a/pkg/v1/agents.go
+++ b/pkg/v1/agents.go
@@ -24,12 +24,15 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/master"
 )
 
 // GetAgents  retrieves information about all the mesos_v1_agents known to the mesos_v1_master.
 func (m *Master) GetAgents(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_AGENTS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_AGENTS)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/container.go
+++ b/pkg/v1/container.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/gogo/protobuf/proto"
 
@@ -36,7 +37,9 @@ import (
 // It contains ContainerStatus and ResourceStatistics along with some metadata
 // of the containers.
 func (a *Agent) GetContainers(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_CONTAINERS)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_CONTAINERS)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -52,7 +55,9 @@ func (a *Agent) LaunchNestedContainer(ctx context.Context, call *mesos_v1_agent.
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = a.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = a.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }
 

--- a/pkg/v1/executors.go
+++ b/pkg/v1/executors.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -31,12 +32,16 @@ import (
 
 // GetExecutors queries about all the executors known to the mesos_v1_master.
 func (m *Master) GetExecutors(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_EXECUTORS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_EXECUTORS)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetExecutors retrieves information about all the executors known to the mesos_v1_agent.
 func (a *Agent) GetExecutors(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_EXECUTORS)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_EXECUTORS)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/file.go
+++ b/pkg/v1/file.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/go-proto/mesos/v1/agent"
@@ -45,9 +46,11 @@ func (m *Master) ListFiles(ctx context.Context, call *mesos_v1_master.Call_ListF
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
+	var httpResponse *http.Response
 	response = &mesos_v1_master.Response{}
 	// Send HTTP Request
-	_, err = m.client.doProtoWrapper(ctx, buf, response)
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, response)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -64,9 +67,11 @@ func (a *Agent) ListFiles(ctx context.Context, call *mesos_v1_agent.Call_ListFil
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
+	var httpResponse *http.Response
 	response = &mesos_v1_agent.Response{}
 	// Send HTTP Request
-	_, err = a.client.doProtoWrapper(ctx, buf, response)
+	httpResponse, err = a.client.doProtoWrapper(ctx, buf, response)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -84,9 +89,11 @@ func (m *Master) ReadFile(ctx context.Context, call *mesos_v1_master.Call_ReadFi
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
+	var httpResponse *http.Response
 	response = &mesos_v1_master.Response{}
 	// Send HTTP Request
-	_, err = m.client.doProtoWrapper(ctx, buf, response)
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, response)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -104,8 +111,10 @@ func (a *Agent) ReadFile(ctx context.Context, call *mesos_v1_agent.Call_ReadFile
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
+	var httpResponse *http.Response
 	response = &mesos_v1_agent.Response{}
 	// Send HTTP Request
-	_, err = a.client.doProtoWrapper(ctx, buf, response)
+	httpResponse, err = a.client.doProtoWrapper(ctx, buf, response)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/flags.go
+++ b/pkg/v1/flags.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -31,12 +32,16 @@ import (
 
 // GetFlags retrieves the master’s overall flag configuration.
 func (m *Master) GetFlags(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_FLAGS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_FLAGS)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetFlags retrieves the mesos_v1_agents overall flag configuration.
 func (a *Agent) GetFlags(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_FLAGS)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_FLAGS)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/frameworks.go
+++ b/pkg/v1/frameworks.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -31,12 +32,16 @@ import (
 
 // GetFrameorks retrieves information about all the frameworks known to the mesos_v1_master.
 func (m *Master) GetFrameworks(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_FRAMEWORKS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_FRAMEWORKS)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetFrameorks retrieves information about all the frameworks known to the mesos_v1_agent.
 func (a *Agent) GetFrameworks(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_FRAMEWORKS)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_FRAMEWORKS)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/health.go
+++ b/pkg/v1/health.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -31,12 +32,16 @@ import (
 
 // GetHealth retrieves the health status of mesos_v1_master.
 func (m *Master) GetHealth(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_HEALTH)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_HEALTH)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetHealth retrieves the health status of agent.
 func (a *Agent) GetHealth(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_HEALTH)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_HEALTH)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/logging_level.go
+++ b/pkg/v1/logging_level.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/go-proto/mesos/v1/agent"
@@ -34,13 +35,17 @@ import (
 
 // GetLoggingLevel retrieves the master’s logging level.
 func (m *Master) GetLoggingLevel(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_LOGGING_LEVEL)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_LOGGING_LEVEL)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetLoggingLevel retrieves the agent's logging level.
 func (a *Agent) GetLoggingLevel(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_LOGGING_LEVEL)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_LOGGING_LEVEL)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -58,7 +63,9 @@ func (m *Master) SetLoggingLevel(ctx context.Context, call *mesos_v1_master.Call
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -76,6 +83,8 @@ func (a *Agent) SetLoggingLevel(ctx context.Context, call *mesos_v1_agent.Call_S
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = a.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = a.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/maintenance.go
+++ b/pkg/v1/maintenance.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -33,13 +34,17 @@ import (
 
 // GetMaintenanceStatus retrieves the cluster’s maintenance status.
 func (m *Master) GetMaintenanceStatus(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_MAINTENANCE_STATUS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_MAINTENANCE_STATUS)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetMaintenanceSchedule retrieves the cluster’s maintenance schedule.
 func (m *Master) GetMaintenanceSchedule(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_MAINTENANCE_SCHEDULE)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_MAINTENANCE_SCHEDULE)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -56,7 +61,9 @@ func (m *Master) UpdateMaintenanceSchedule(ctx context.Context, call *mesos_v1_m
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -74,7 +81,9 @@ func (m *Master) StartMaintenance(ctx context.Context, call *mesos_v1_master.Cal
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -89,6 +98,8 @@ func (m *Master) StopMaintenance(ctx context.Context, call *mesos_v1_master.Call
 	var b []byte
 	b, err = proto.Marshal(payload)
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/master.go
+++ b/pkg/v1/master.go
@@ -108,6 +108,8 @@ func (m *Master) sendSimpleCall(ctx context.Context, callType mesos_v1_master.Ca
 
 // GetMaster retrieves information about the mesos_v1_master.
 func (m *Master) GetMaster(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_MASTER)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_MASTER)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/metrics.go
+++ b/pkg/v1/metrics.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -34,7 +35,9 @@ import (
 // the API will take to respond. If the timeout is exceeded, some metrics may
 // not be included in the response.
 func (m *Master) GetMetrics(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_METRICS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_METRICS)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -43,6 +46,8 @@ func (m *Master) GetMetrics(ctx context.Context) (response *mesos_v1_master.Resp
 // the API will take to respond. If the timeout is exceeded, some metrics may
 // not be included in the response.
 func (a *Agent) GetMetrics(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_METRICS)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_METRICS)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/quota.go
+++ b/pkg/v1/quota.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -33,7 +34,9 @@ import (
 
 // GetQuota retrieves the cluster’s configured quotas.
 func (m *Master) GetQuota(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_QUOTA)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_QUOTA)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -47,7 +50,9 @@ func (m *Master) SetQuota(ctx context.Context, call *mesos_v1_master.Call_SetQuo
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -61,6 +66,8 @@ func (m *Master) RemoveQuota(ctx context.Context, call *mesos_v1_master.Call_Rem
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/resources.go
+++ b/pkg/v1/resources.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -41,7 +42,9 @@ func (m *Master) ReserveResource(ctx context.Context, call *mesos_v1_master.Call
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -55,6 +58,8 @@ func (m *Master) UnreserveResource(ctx context.Context, call *mesos_v1_master.Ca
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/roles.go
+++ b/pkg/v1/roles.go
@@ -24,12 +24,15 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/master"
 )
 
 // GetRoles queries the information about roles.
 func (m *Master) GetRoles(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_ROLES)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_ROLES)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/state.go
+++ b/pkg/v1/state.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -31,7 +32,9 @@ import (
 
 // GetState retrieves the overall cluster state.
 func (m *Master) GetState(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_STATE)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_STATE)
+	defer httpResponse.Body.Close()
 	return
 }
 

--- a/pkg/v1/subscribe.go
+++ b/pkg/v1/subscribe.go
@@ -58,6 +58,7 @@ func (m *Master) Subscribe(ctx context.Context, es EventStream) (err error) {
 		return
 	}
 	var reader *bufio.Reader = bufio.NewReader(httpResponse.Body)
+	defer httpResponse.Body.Close()
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/v1/tasks.go
+++ b/pkg/v1/tasks.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -31,12 +32,16 @@ import (
 
 // GetTasks queries about all the tasks known to the mesos_v1_master.
 func (m *Master) GetTasks(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_TASKS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_TASKS)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetTasks queries about all the tasks known to the agent.
 func (a *Agent) GetTasks(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_TASKS)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_TASKS)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/v1.go
+++ b/pkg/v1/v1.go
@@ -280,6 +280,8 @@ func (c *client) doProto(ctx context.Context, body io.Reader, pb proto.Message) 
 
 	req = req.WithContext(ctx)
 
+	defer req.Body.Close()
+
 	httpRes, err = c.httpclient.Do(req)
 	if err != nil {
 		return

--- a/pkg/v1/version.go
+++ b/pkg/v1/version.go
@@ -24,6 +24,7 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/agent"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -31,12 +32,16 @@ import (
 
 // GetVersion retrieves the master’s version information.
 func (m *Master) GetVersion(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_VERSION)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_VERSION)
+	defer httpResponse.Body.Close()
 	return
 }
 
 // GetVersion retrieves the mesos_v1_agent's version information.
 func (a *Agent) GetVersion(ctx context.Context) (response *mesos_v1_agent.Response, err error) {
-	response, _, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_VERSION)
+	var httpResponse *http.Response
+	response, httpResponse, err = a.sendSimpleCall(ctx, mesos_v1_agent.Call_GET_VERSION)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/volumes.go
+++ b/pkg/v1/volumes.go
@@ -26,6 +26,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/mesos/go-proto/mesos/v1/master"
@@ -44,7 +45,9 @@ func (m *Master) CreateVolumes(ctx context.Context, call *mesos_v1_master.Call_C
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }
 
@@ -59,6 +62,8 @@ func (m *Master) DestroyVolumes(ctx context.Context, call *mesos_v1_master.Call_
 		return
 	}
 	var buf io.Reader = bytes.NewBuffer(b)
-	_, err = m.client.doProtoWrapper(ctx, buf, nil)
+	var httpResponse *http.Response
+	httpResponse, err = m.client.doProtoWrapper(ctx, buf, nil)
+	defer httpResponse.Body.Close()
 	return
 }

--- a/pkg/v1/weights.go
+++ b/pkg/v1/weights.go
@@ -24,12 +24,15 @@ package v1
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/mesos/go-proto/mesos/v1/master"
 )
 
 // GetWeights retrieves the information about role weights
 func (m *Master) GetWeights(ctx context.Context) (response *mesos_v1_master.Response, err error) {
-	response, _, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_WEIGHTS)
+	var httpResponse *http.Response
+	response, httpResponse, err = m.sendSimpleCall(ctx, mesos_v1_master.Call_GET_WEIGHTS)
+	defer httpResponse.Body.Close()
 	return
 }


### PR DESCRIPTION
* Request Body
```
    // Body is the request's body.
    //
    // For client requests a nil body means the request has no
    // body, such as a GET request. The HTTP Client's Transport
    // is responsible for calling the Close method.
    //
    // For server requests the Request Body is always non-nil
    // but will return EOF immediately when no body is present.
    // The Server will close the request body. The ServeHTTP
    // Handler does not need to.
    Body io.ReadCloser
```
* Response Body
```
    // Body represents the response body.
    //
    // The http Client and Transport guarantee that Body is always
    // non-nil, even on responses without a body or responses with
    // a zero-length body. It is the caller's responsibility to
    // close Body. The default HTTP client's Transport does not
    // attempt to reuse HTTP/1.0 or HTTP/1.1 TCP connections
    // ("keep-alive") unless the Body is read to completion and is
    // closed.
    //
    // The Body is automatically dechunked if the server replied
    // with a "chunked" Transfer-Encoding.
    Body io.ReadCloser
```