### PR TITLE
Removing repotoken flag from goveralls invocation

### DIFF
--- a/script/coveralls.sh
+++ b/script/coveralls.sh
@@ -28,7 +28,4 @@ if [ $exit_val -ne 0 ]; then
 fi
 
 # post it
-$HOME/gopath/bin/goveralls    \
-  -coverprofile=aggregate.out \
-  -service=travis-ci          \
-  -repotoken $COVERALLS_TOKEN
+$HOME/gopath/bin/goveralls -coverprofile=aggregate.out -service=travis-ci


### PR DESCRIPTION
References:

* https://github.com/mattn/goveralls#github-integration

  ```For a public github repository, it is not necessary to define your repository key (COVERALLS_TOKEN).```